### PR TITLE
fix(ll-box): use /proc/<pid>/stat to find the target pid

### DIFF
--- a/libs/linglong/src/linglong/package/uab_packager.h
+++ b/libs/linglong/src/linglong/package/uab_packager.h
@@ -17,6 +17,7 @@
 #include <QString>
 #include <QUuid>
 
+#include <filesystem>
 #include <unordered_set>
 
 namespace linglong::package {


### PR DESCRIPTION
add a fallback for compatible with linux kernel which compiled with CONFIG_PROC_CHILDREN=false