### PR TITLE
fix: build failed on fedora

### DIFF
--- a/rpm/linglong.spec
+++ b/rpm/linglong.spec
@@ -1,3 +1,4 @@
+%global debug_package %{nil}
 Name:           linglong
 Version:        1.4.3
 Release:        1


### PR DESCRIPTION
修复fedora构建报debug目录文件未添加到包