### PR TITLE
fix: uab is not enabled in deepin system

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@ ARCH=$(shell dpkg-architecture -qDEB_TARGET_MULTIARCH)
 ENABLE_UAB_SUPPORT=FALSE
 ENABLE_STATIC_BOX=FALSE
 
-ifeq ($(OS) $(OS_VERSION), deepin)
+ifeq ($(OS), deepin)
 ENABLE_UAB_SUPPORT=TRUE
 ENABLE_STATIC_BOX=TRUE
 endif


### PR DESCRIPTION
为在deepin 25上也启用uab功能, 删除了cmakefile的版本号
但未删除前面的版本变量, 导致在deepin上if匹配失败