### PR TITLE
chore: rename 'dumb-init' to 'll-init' for consistency

### DIFF
--- a/debian/linglong-bin.install
+++ b/debian/linglong-bin.install
@@ -17,7 +17,7 @@ usr/libexec/linglong/ld-cache-generator
 usr/libexec/linglong/font-cache-generator
 usr/libexec/linglong/ll-dialog
 usr/libexec/linglong/dialog/99-linglong-permission
-usr/libexec/linglong/dumb-init
+usr/libexec/linglong/ll-init
 usr/share/bash-completion/completions/ll-cli
 usr/share/zsh/vendor-completions/_ll-cli
 usr/share/dbus-1/system-services/org.deepin.linglong.PackageManager1.service

--- a/rpm/linglong.spec
+++ b/rpm/linglong.spec
@@ -88,7 +88,7 @@ cd build
 %{_libexecdir}/%{name}/ld-cache-generator
 %{_libexecdir}/%{name}/font-cache-generator
 %{_libexecdir}/%{name}/ll-dialog
-%{_libexecdir}/%{name}/dumb-init
+%{_libexecdir}/%{name}/ll-init
 %{_libexecdir}/%{name}/dialog/99-linglong-permission
 %{_datadir}/bash-completion/completions/ll-cli
 %{_datadir}/zsh/vendor-completions/_ll-cli


### PR DESCRIPTION
Updates file references in Debian and RPM installation scripts to rename 'dumb-init' to 'll-init', aligning with naming conventions and improving clarity. No functional changes introduced.