### PR TITLE
chore: remove liblief-dev build dependencie

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,8 +29,7 @@ Build-Depends: cmake,
                qt6-base-dev | qtbase5-dev,
                qt6-base-private-dev | qtbase5-private-dev,
                systemd,
-               zlib1g-dev,
-               liblief-dev
+               zlib1g-dev
 Standards-Version: 4.1.3
 Homepage: http://www.deepin.org
 


### PR DESCRIPTION
liblief-dev uses the project internally instead of the repository.