### PR TITLE
chore: disable dwz compression

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,8 @@
 #!/usr/bin/make -f
 include /usr/share/dpkg/pkg-info.mk
 
+export DEB_BUILD_OPTIONS += nodwz
+
 %:
 	dh $@ --buildsystem=cmake
 
@@ -8,9 +10,6 @@ EXTRA_OPTION = -DCPM_LOCAL_PACKAGES_ONLY=ON -DLINGLONG_VERSION=$(DEB_VERSION_UPS
 
 override_dh_auto_configure:
 	dh_auto_configure --  ${EXTRA_OPTION}  ${DH_AUTO_ARGS}
-
-override_dh_strip:
-    dh_strip --no-dwz
 
 # https://sources.debian.org/src/amavisd-new/1:2.13.0-3/debian/rules/?hl=10#L10
 execute_after_dh_installinit:


### PR DESCRIPTION
Disables dwz compression during the build process. This is achieved by setting the `DEB_BUILD_OPTIONS` environment variable to include `nodwz`.