### PR TITLE
feat: add apt token support for ostree repo

### DIFF
--- a/debian/patches/0005-repo-token.patch
+++ b/debian/patches/0005-repo-token.patch
@@ -1,0 +1,44 @@
+Index: linglong/libs/linglong/src/linglong/repo/ostree_repo.cpp
+===================================================================
+--- linglong.orig/libs/linglong/src/linglong/repo/ostree_repo.cpp
++++ linglong/libs/linglong/src/linglong/repo/ostree_repo.cpp
+@@ -1270,6 +1270,20 @@ utils::error::Result<void> OSTreeRepo::p
+     return LINGLONG_OK;
+ }
+ 
++// 执行apt-config 获取 apt token配置
++utils::error::Result<std::string> getAptToken() noexcept
++{
++    LINGLONG_TRACE("get apt token");
++    auto aptToken = utils::command::Exec("sh", {
++    "-c",
++    "eval `apt-config shell Token Acquire::SmartMirrors::Token`; echo $Token",
++    });
++    if (!aptToken) {
++        return LINGLONG_ERR(aptToken);
++    }
++    return aptToken->toStdString();
++}
++
+ // 初始化一个GVariantBuilder
+ GVariantBuilder OSTreeRepo::initOStreePullOptions(const std::string &ref) noexcept
+ {
+@@ -1290,6 +1304,18 @@ GVariantBuilder OSTreeRepo::initOStreePu
+                           "{s@v}",
+                           "refs",
+                           g_variant_new_variant(g_variant_new_strv(refs.data(), -1)));
++    auto token = getAptToken();
++    if (!token) {
++        qWarning() << "get apt token error: " << token.error().message();
++    } else {
++        GVariantBuilder hdr_builder;
++        g_variant_builder_init(&hdr_builder, G_VARIANT_TYPE("a(ss)"));
++        g_variant_builder_add(&hdr_builder, "(ss)", "X-Repo-Token", token->c_str());
++        g_variant_builder_add(&builder,
++                              "{s@v}",
++                              "http-headers",
++                              g_variant_new_variant(g_variant_builder_end(&hdr_builder)));
++    }
+     return builder;
+ }
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@
 0001-add-mount-dirs.patch
 0002-deepin-specifies-export-directory.patch
 0003-add-linyaps-preloader.patch
+0005-repo-token.patch


### PR DESCRIPTION
1. Added new function getAptToken() to retrieve apt configuration token
2. Modified initOStreePullOptions() to include token in HTTP headers if available
3. The token is obtained via apt-config shell command
4. Error handling added for cases when token retrieval fails
5. Patch added to debian/patches series file

This change enables the ostree repository to use apt configuration tokens when making HTTP requests, which may be required for authentication with certain repository mirrors.

feat: 为 ostree 仓库添加 apt token 支持

1. 新增 getAptToken() 函数用于获取 apt 配置的 token
2. 修改 initOStreePullOptions() 在 HTTP 头中包含 token（如果可用）
3. 通过 apt-config shell 命令获取 token
4. 添加了 token 获取失败时的错误处理
5. 将补丁添加到 debian/patches 系列文件中

此项变更使得 ostree 仓库在进行 HTTP 请求时能够使用 apt 配置的 token，这
对于需要认证的特定仓库镜像是必要的。