### PR TITLE
chore: bump linglong-box dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,7 @@ Architecture: any
 Depends: desktop-file-utils,
          erofsfuse,
          libglib2.0-bin,
-         linglong-box (>= 1.9.0) | crun,
+         linglong-box (>= 2.1.0) | crun,
          shared-mime-info,
          ${misc:Depends},
          ${shlibs:Depends}


### PR DESCRIPTION
Update the linglong-box dependency to version 2.1.0.

This change is necessary because version 2.1.0 contains critical bug fixes and performance improvements that are required for proper functionality of this package. Specifically, it addresses issues related to resource management and container stability.

Influence:
1. Verify that the package correctly declares its dependency on linglong-box (>= 2.1.0).
2. Test the package with linglong-box version 2.1.0 to ensure compatibility and proper functioning.
3. Test the package with crun as an alternative runtime.

chore: 提升 linglong-box 依赖版本

将 linglong-box 的依赖更新到 2.1.0 版本。

这个变更是必要的，因为 2.1.0 版本包含了关键的错误修复和性能改进，这些改
进是此软件包正常运行所必需的。 特别是，它解决了与资源管理和容器稳定性相
关的问题。

Influence:
1. 验证软件包是否正确声明了对 linglong-box (>= 2.1.0) 的依赖。
2. 使用 linglong-box 2.1.0 版本测试软件包，以确保兼容性和正常运行。
3. 使用 crun 作为替代运行时测试软件包。