### PR TITLE
chore: install missing desktop icon

### DIFF
--- a/debian/linglong-bin.install
+++ b/debian/linglong-bin.install
@@ -28,3 +28,4 @@ usr/share/locale
 usr/share/mime/packages/vnd.linyaps.uab.xml
 usr/share/polkit-1/actions/org.deepin.linglong.PackageManager1.policy
 usr/share/applications/linyaps.desktop
+usr/share/icons/hicolor/scalable/apps/linyaps.svg


### PR DESCRIPTION
The desktop icon file `usr/share/icons/hicolor/scalable/apps/ linyaps.svg` was not being installed, causing the application to lack a proper icon on the desktop environment. This commit adds the installation instruction to the `debian/linglong-bin.install` file, ensuring that the icon is included during package installation. This improves the user experience by providing a visual representation of the application.

Influence:
1. Verify that the desktop icon is displayed correctly after installation.