### PR TITLE
fix: restructure package dependencies for better system integration

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Priority: optional
 Maintainer: Deepin Packages Builder <packages@deepin.com>
 Build-Depends: cmake,
                debhelper-compat (= 12),
-               erofsfuse,
                intltool,
                libcli11-dev (>= 2.4.1) | hello,
                libcurl4-openssl-dev,
@@ -40,6 +39,8 @@ Depends: desktop-file-utils,
          libglib2.0-bin,
          linglong-box | crun,
          shared-mime-info,
+         pkexec,
+         erofs-utils,
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: linglong-dbus-proxy
@@ -50,13 +51,13 @@ Description: Linglong package manager.
 Package: linglong-builder
 Architecture: any
 Depends: erofs-utils,
-         erofsfuse,
          fuse-overlayfs,
          git,
          linglong-bin,
          linglong-box | crun,
          ${misc:Depends},
          ${shlibs:Depends}
-Recommends: devscripts, linglong-loader
+Recommends: linglong-loader
+Suggests: devscripts
 Description: Linglong application building tools.
  ll-builder is a tool that makes it easy to build applications and dependencies.

--- a/rpm/linglong.spec
+++ b/rpm/linglong.spec
@@ -22,12 +22,14 @@ This package is a linglong package framework.
 %package        -n linglong-bin
 Summary:        Linglong package manager
 Requires:       linglong-box
+Requires:       pkexec erofs-utils erofsfuse
 %description    -n linglong-bin
 Linglong package management command line tool.
 
 %package        -n linglong-builder
 Summary:        Linglong build tools
 Requires:       linglong-box linglong-bin = %{version}-%{release}
+Requires:       erofs-utils fuse-overlayfs git
 %description    -n linglong-builder
 This package is a tool that makes it easy to build applications and dependencies.
 


### PR DESCRIPTION
1. Move erofsfuse from build dependency to runtime dependency for linglong-bin
2. Add pkexec and erofs-utils as runtime dependencies for enhanced privilege management
3. Reorganize linglong-builder dependencies by moving devscripts from Recommends to Suggests
4. Add explicit runtime dependencies in RPM spec for both linglong-bin and linglong-builder packages
5. Ensure proper EROFS filesystem support is available at runtime rather than build time

This restructuring improves package installation reliability by ensuring all necessary tools are available when the software runs, particularly for filesystem operations and privilege escalation scenarios.

fix: 重构软件包依赖关系以改善系统集成

1. 将 erofsfuse 从构建依赖移至 linglong-bin 的运行时依赖
2. 添加 pkexec 和 erofs-utils 作为运行时依赖以增强权限管理
3. 重新组织 linglong-builder 依赖关系，将 devscripts 从推荐依赖改为建议 依赖
4. 在 RPM 规范文件中为 linglong-bin 和 linglong-builder 包添加明确的运行 时依赖
5. 确保 EROFS 文件系统支持在运行时而非构建时可用

此重构通过确保软件运行时所有必要工具都可用来提高软件包安装的可靠性，特别
是针对文件系统操作和权限提升场景。