### PR TITLE
feat: add icons to linglong package data

### DIFF
--- a/rpm/linglong.spec
+++ b/rpm/linglong.spec
@@ -102,6 +102,7 @@ cd build
 %{_datadir}/mime/packages/*
 %{_datadir}/locale/*
 %{_datadir}/applications/*
+%{_datadir}/icons/*
 
 %files -n linglong-builder
 %license LICENSE


### PR DESCRIPTION
Add icon files to the installed data.

The icon files were missing from the list of installed files, leading to potential problems with desktop integration, especially in environments where applications rely on standard icon paths. Including them ensures that application icons are correctly installed and available system- wide.

Influence:
1. Verify the correct installation of icon files under %{_datadir}/ icons/*
2. Check if applications using linglong are displaying icons correctly after this change