### PR TITLE
fix: adjust package dependencies in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,16 +35,16 @@ Homepage: http://www.deepin.org
 Package: linglong-bin
 Architecture: any
 Depends: desktop-file-utils,
-         erofsfuse,
          libglib2.0-bin,
          linglong-box | crun,
          shared-mime-info,
-         pkexec,
+         pkexec | policykit-1,
          erofs-utils,
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: linglong-dbus-proxy
 Conflicts: linglong-dbus-proxy
+Recommends: erofsfuse
 Description: Linglong package manager.
  Linglong package management command line tool.
 

--- a/rpm/linglong.spec
+++ b/rpm/linglong.spec
@@ -22,14 +22,16 @@ This package is a linglong package framework.
 %package        -n linglong-bin
 Summary:        Linglong package manager
 Requires:       linglong-box
-Requires:       pkexec erofs-utils erofsfuse
+Requires:       pkexec erofs-utils
+Recommends:     erofsfuse
 %description    -n linglong-bin
 Linglong package management command line tool.
 
 %package        -n linglong-builder
 Summary:        Linglong build tools
 Requires:       linglong-box linglong-bin = %{version}-%{release}
-Requires:       erofs-utils fuse-overlayfs git
+Requires:       erofs-utils fuse-overlayfs
+Recommends:     git
 %description    -n linglong-builder
 This package is a tool that makes it easy to build applications and dependencies.
 


### PR DESCRIPTION
- Remove erofsfuse from Depends and add to Recommends
- Add policykit-1 as alternative to pkexec
- Keep erofs-utils in Depends for essential functionality