### PR TITLE
chore: add build dependencies for erofs and gettext

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,6 +29,8 @@ Build-Depends: cmake,
                qt6-base-private-dev | qtbase5-private-dev,
                systemd,
                zlib1g-dev,
+               gettext,
+               erofs-utils,
                libcap-dev
 Standards-Version: 4.1.3
 Homepage: http://www.deepin.org

--- a/rpm/linglong.spec
+++ b/rpm/linglong.spec
@@ -13,8 +13,8 @@ BuildRequires:  glib2-devel nlohmann-json-devel ostree-devel yaml-cpp-devel
 BuildRequires:  systemd-devel gtest-devel elfutils-libelf-devel
 BuildRequires:  glibc-static libstdc++-static
 BuildRequires:  libcurl-devel openssl-devel
-BuildRequires:  gtest-devel gmock-devel
-BuildRequires:  libcap-devel
+BuildRequires:  gtest-devel gmock-devel erofs-utils
+BuildRequires:  libcap-devel gettext-devel
 Requires:       linglong-bin = %{version}-%{release}
 
 %description


### PR DESCRIPTION
Added gettext and erofs-utils as build dependencies in both Debian and RPM package configurations. These dependencies are required for supporting new features related to internationalization and the EROFS filesystem integration in the linglong package.

The changes include:
1. Added gettext to both Debian and RPM build dependencies for i18n support
2. Added erofs-utils to support EROFS filesystem operations
3. Updated both Debian control and RPM spec files consistently

Influence:
1. Verify package builds successfully with new dependencies
2. Test internationalization features if applicable
3. Check EROFS related functionality in the application

chore: 为 erofs 和 gettext 添加构建依赖

在 Debian 和 RPM 包配置中添加了 gettext 和 erofs-utils 作为构建依赖。 这些依赖是支持 linglong 包中与国际化和 EROFS 文件系统集成相关新功能所必
需的。

变更包括：
1. 为 i18n 支持添加 gettext 到 Debian 和 RPM 构建依赖
2. 添加 erofs-utils 以支持 EROFS 文件系统操作
3. 同时更新了 Debian control 和 RPM spec 文件

Influence:
1. 验证包是否能够使用新依赖成功构建
2. 测试国际化功能（如适用）
3. 检查应用中与 EROFS 相关的功能