### PR TITLE
chore: add ll-driver-detect to package installation list

### DIFF
--- a/debian/linglong-bin.install
+++ b/debian/linglong-bin.install
@@ -16,6 +16,7 @@ usr/libexec/linglong/ll-session-helper
 usr/libexec/linglong/ld-cache-generator
 usr/libexec/linglong/font-cache-generator
 usr/libexec/linglong/ll-dialog
+usr/libexec/linglong/ll-driver-detect
 usr/libexec/linglong/dialog/99-linglong-permission
 usr/libexec/linglong/ll-init
 usr/share/bash-completion/completions/ll-cli


### PR DESCRIPTION
Added ll-driver-detect binary to the Debian package installation script to ensure it gets properly installed alongside other Linglong executables. This file was missing from the installation list, which could cause missing file errors during package deployment.

Influence:
1. Verify ll-driver-detect is present in /usr/libexec/linglong/ after package installation
2. Check that the binary has proper execution permissions
3. Test package installation process completes without errors
4. Verify all listed binaries are correctly installed in their respective locations