### PR TITLE
fix: include config.json in debian package install

### DIFF
--- a/debian/linglong-bin.install
+++ b/debian/linglong-bin.install
@@ -1,6 +1,7 @@
 debian/sysctl.d/linglong.conf usr/lib/sysctl.d/
 etc/X11/Xsession.d/21linglong
 etc/profile.d/linglong.sh
+etc/linglong/config.json
 usr/bin/ll-cli
 usr/bin/llpkg
 usr/lib/linglong/*


### PR DESCRIPTION
1. Add etc/linglong/config.json to debian/linglong-bin.install manifest
2. Ensure the configuration file is properly included in the Debian package
3. Fix packaging oversight where the config file was not being installed to target systems

Influence:
1. Verify that etc/linglong/config.json exists in the built Debian package
2. Test package installation to confirm config.json is deployed to / etc/linglong/
3. Check file permissions and ownership of the installed configuration file
4. Verify the application can read the configuration file after installation
5. Test upgrade scenarios to ensure config file handling works correctly