### PR TITLE
fix: remove service resource limits

### DIFF
--- a/misc/lib/systemd/system/org.deepin.linglong.PackageManager.service
+++ b/misc/lib/systemd/system/org.deepin.linglong.PackageManager.service
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -11,6 +11,3 @@ User=@LINGLONG_USERNAME@
 Group=@LINGLONG_USERNAME@
 BusName=org.deepin.linglong.PackageManager1
 ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong/ll-package-manager
-MemoryMax=8G
-Restart=on-failure
-RestartSec=10


### PR DESCRIPTION
1. Remove MemoryMax=8G constraint to allow package manager to use required memory for large operations
2. Remove Restart=on-failure and RestartSec=10 to prevent automatic service restarts that could mask underlying issues

Influence:
1. Verify package manager can handle large packages without being killed by OOM
2. Test that service failures are properly reported instead of being silently restarted
3. Verify service behavior when encountering errors during package operations
4. Monitor memory usage during large package installations to ensure system stability