### PR TITLE
feat: enable atspi in system config

### DIFF
--- a/debian/patches/0006-feat-add-system-config.patch
+++ b/debian/patches/0006-feat-add-system-config.patch
@@ -27,11 +27,12 @@ Index: linyaps/misc/etc/linglong/config.json
 ===================================================================
 --- /dev/null
 +++ linyaps/misc/etc/linglong/config.json
-@@ -0,0 +1,7 @@
+@@ -0,0 +1,8 @@
 +{
 +    "device_mode": [
 +        "passthru"
 +    ],
 +    "disable_xdp": true,
-+    "enable_pipewire": true
++    "enable_pipewire": true,
++    "enable_atspi": true
 +}


### PR DESCRIPTION
Add "enable_atspi" configuration option to the default system config JSON,
enabling the AT-SPI (Assistive Technology Service Provider Interface) service
for accessibility support. This change is made to allow applications to utilize accessibility features without requiring additional manual configuration.

Log: Added AT-SPI enable option in default system config

Influence:
1. Verify the updated config.json contains the "enable_atspi" field set to true
2. Test that applications requiring AT-SPI (e.g., screen readers) work correctly when using the system config
3. Ensure backward compatibility – existing configurations without this field still work as expected