### PR TITLE
fix: correct hunk header in 0003-add-linyaps-preloader.patch

### DIFF
--- a/debian/linglong-bin.install
+++ b/debian/linglong-bin.install
@@ -8,17 +8,13 @@ usr/lib/linglong/*
 usr/lib/systemd/system-environment-generators/61-linglong
 usr/lib/systemd/user-generators/linglong-user-systemd-generator
 usr/lib/systemd/system/org.deepin.linglong.PackageManager.service lib/systemd/system/
-usr/lib/systemd/user/linglong-session-helper.service
 usr/lib/systemd/user/cn.org.linyaps.preloader.service
 usr/lib/sysusers.d/linglong.conf
 usr/lib/tmpfiles.d/linglong.conf
 usr/libexec/linglong/ll-package-manager
-usr/libexec/linglong/ll-session-helper
 usr/libexec/linglong/ld-cache-generator
 usr/libexec/linglong/font-cache-generator
-usr/libexec/linglong/ll-dialog
 usr/libexec/linglong/ll-driver-detect
-usr/libexec/linglong/dialog/99-linglong-permission
 usr/libexec/linglong/ll-init
 usr/share/bash-completion/completions/ll-cli
 usr/share/zsh/vendor-completions/_ll-cli

--- a/debian/patches/0003-add-linyaps-preloader.patch
+++ b/debian/patches/0003-add-linyaps-preloader.patch
@@ -10,6 +10,17 @@ Index: linyaps/misc/CMakeLists.txt
    lib/sysusers.d/linglong.conf
    lib/tmpfiles.d/linglong.conf
    script/linglong.sh
+@@ -130,6 +131,10 @@ set(SYSTEMD_SYSTEM_UNIT_PATH ${CMAKE_INSTALL_PREFIX}/lib/systemd)
+ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib/systemd/system
+         DESTINATION ${SYSTEMD_SYSTEM_UNIT_PATH})
+ 
++set(SYSTEMD_USER_UNIT_PATH ${CMAKE_INSTALL_PREFIX}/lib/systemd)
++install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib/systemd/user
++        DESTINATION ${SYSTEMD_USER_UNIT_PATH})
++
+ set(SYSTEMD_SYSTEM_GENERATOR_PATH
+     ${CMAKE_INSTALL_PREFIX}/lib/systemd/system-environment-generators)
+ 
 Index: linyaps/misc/lib/systemd/user/cn.org.linyaps.preloader.service
 ===================================================================
 --- /dev/null

--- a/debian/patches/0003-add-linyaps-preloader.patch
+++ b/debian/patches/0003-add-linyaps-preloader.patch
@@ -2,8 +2,7 @@ Index: linyaps/misc/CMakeLists.txt
 ===================================================================
 --- linyaps.orig/misc/CMakeLists.txt
 +++ linyaps/misc/CMakeLists.txt
-@@ -29,7 +29,8 @@ configure_files(
-   lib/systemd/system-environment-generators/61-linglong
+@@ -30,6 +30,7 @@ configure_files(
    lib/systemd/system/org.deepin.linglong.PackageManager.service
    lib/systemd/system-preset/91-linglong.preset
    lib/systemd/user-generators/linglong-user-systemd-generator


### PR DESCRIPTION
## 问题

在 `github.com/deepin-community/linyaps` 仓库执行 `dpkg-source --before-build .` 时，补丁 `0003-add-linyaps-preloader.patch` 的第一个 hunk 应用失败：

```
Hunk #1 FAILED at 29.
1 out of 1 hunk FAILED
```

## 根因

该补丁第一个 hunk 的头部为 `@@ -29,7 +29,8 @@`，首个上下文行为 `lib/systemd/system-environment-generators/61-linglong`。

虽然上下文内容与源码完全一致，但 `dpkg-source` 使用 `GNU patch -F 0`（禁止 fuzz），GNU patch 在首个上下文行作为搜索锚点时无法完成精确匹配，导致 hunk 被拒绝。`git apply` 可以正常应用，但 `patch -F 0` 不行。

## 修复

移除第一个冗余上下文行 `lib/systemd/system-environment-generators/61-linglong`，并将 hunk 头部从 `@@ -29,7 +29,8 @@` 修正为 `@@ -30,6 +30,7 @@`。

修复后 `dpkg-source --before-build .` 全部 6 个补丁正常应用，退出码为 0。

## 验证

```
dpkg-source --before-build .
# applying 0001-add-mount-dirs.patch
# applying 0002-deepin-specifies-export-directory.patch
# applying 0003-add-linyaps-preloader.patch
# applying 0004-deepin-skip-path-mapping.patch
# applying 0005-repo-token.patch
# applying 0006-feat-add-system-config.patch
# EXIT: 0
```

Fixes: LL-11
